### PR TITLE
Fix wrong serialization of FTS query parameters

### DIFF
--- a/scala-client/src/main/scala/com/couchbase/client/scala/search/SearchOptions.scala
+++ b/scala-client/src/main/scala/com/couchbase/client/scala/search/SearchOptions.scala
@@ -223,13 +223,13 @@ case class SearchOptions(
       }
 
       highlightFields.foreach(hf => {
-        if (hf.nonEmpty) highlight.put("fields", JsonArray(hf : _*))
+        if (hf.nonEmpty) highlight.put("fields", JsonArray(hf: _*))
       })
 
       queryJson.put("highlight", highlight)
     })
     fields.foreach(f => {
-      if (f.nonEmpty) queryJson.put("fields", JsonArray(f : _*))
+      if (f.nonEmpty) queryJson.put("fields", JsonArray(f: _*))
     })
 
     sort.foreach(sortParams => {

--- a/scala-client/src/main/scala/com/couchbase/client/scala/search/SearchOptions.scala
+++ b/scala-client/src/main/scala/com/couchbase/client/scala/search/SearchOptions.scala
@@ -229,13 +229,13 @@ case class SearchOptions(
       }
 
       highlightFields.foreach(hf => {
-        if (hf.nonEmpty) highlight.put("fields", JsonArray(hf))
+        if (hf.nonEmpty) highlight.put("fields", JsonArray(hf : _*))
       })
 
       queryJson.put("highlight", highlight)
     })
     fields.foreach(f => {
-      if (f.nonEmpty) queryJson.put("fields", JsonArray(f))
+      if (f.nonEmpty) queryJson.put("fields", JsonArray(f : _*))
     })
 
     sort.foreach(v => queryJson.put("sort", v))

--- a/scala-client/src/main/scala/com/couchbase/client/scala/search/queries/DocIdQuery.scala
+++ b/scala-client/src/main/scala/com/couchbase/client/scala/search/queries/DocIdQuery.scala
@@ -42,7 +42,7 @@ case class DocIdQuery(
   }
 
   override protected def injectParams(input: JsonObject): Unit = {
-    input.put("ids", JsonArray(docIds))
+    input.put("ids", JsonArray(docIds: _*))
     boost.foreach(v => input.put("boost", v))
   }
 }

--- a/scala-client/src/main/scala/com/couchbase/client/scala/search/queries/PhraseQuery.scala
+++ b/scala-client/src/main/scala/com/couchbase/client/scala/search/queries/PhraseQuery.scala
@@ -51,7 +51,7 @@ case class PhraseQuery(
   }
 
   override protected def injectParams(input: JsonObject): Unit = {
-    input.put("terms", JsonArray(terms))
+    input.put("terms", JsonArray(terms: _*))
     boost.foreach(v => input.put("boost", v))
     field.foreach(v => input.put("field", v))
   }

--- a/scala-client/src/main/scala/com/couchbase/client/scala/search/queries/QueryStringQuery.scala
+++ b/scala-client/src/main/scala/com/couchbase/client/scala/search/queries/QueryStringQuery.scala
@@ -29,6 +29,14 @@ case class QueryStringQuery(
     private[scala] val boost: Option[Double] = None
 ) extends SearchQuery {
 
+  /** If specified, only this field will be matched.
+   *
+   * @return a copy of this, for chaining
+   */
+  def field(field: String): QueryStringQuery = {
+    copy(field = Some(field))
+  }
+
   /** The boost parameter is used to increase the relative weight of a clause (with a boost greater than 1) or decrease
     * the relative weight (with a boost between 0 and 1)
     *

--- a/scala-client/src/main/scala/com/couchbase/client/scala/search/sort/SearchSort.scala
+++ b/scala-client/src/main/scala/com/couchbase/client/scala/search/sort/SearchSort.scala
@@ -31,7 +31,7 @@ sealed trait SearchSort {
 
   private[scala] def injectParams(queryJson: JsonObject): Unit = {
     queryJson.put("by", identifier)
-    descending.foreach(desc => queryJson.put("desc", true))
+    descending.foreach(desc => queryJson.put("desc", desc))
   }
 }
 

--- a/scala-implicits/src/main/scala/com/couchbase/client/scala/json/JsonArraySafe.scala
+++ b/scala-implicits/src/main/scala/com/couchbase/client/scala/json/JsonArraySafe.scala
@@ -217,7 +217,7 @@ object JsonArraySafe {
     *         (JsonArraySafe)`
     */
   def fromJson(json: String): Try[JsonArraySafe] = {
-    Try(JsonArraySafe(JsonArray.create))
+    Try(JsonArraySafe(JsonArray.fromJson(json)))
   }
 
   /** Constructs a `JsonArraySafe` from the supplied values.


### PR DESCRIPTION
The `JsonArray()` constructor expects varargs to be passed in, so `Seq`-like type have to be destructured.

Currently a `JsonArray` containing the `Seq` itself is created instead of creating a `JsonArray` containing the values of the `Seq`.
This serializes to an invalid FTS query that gets denied by the server:

```
Exception in thread "main" com.couchbase.client.core.error.CouchbaseException: Unknown search error: "rest_index: Query, indexName: search, err: bleve: QueryBleve parsing searchRequest, err: cbft.SearchRequest: Fields: []string: ReadString: expects \" or n, but found {, error found in #10 byte of ...|fields\":[{\"empty\":fa|..., bigger context ...|t\":[{\"field\":\"lastname\",\"by\":\"field\"}],\"fields\":[{\"empty\":false,\"traversableAgain\":true}]}|..." {"completed":true,"coreId":"0x1836c9f400000001","httpStatus":400,"idempotent":true,"lastDispatchedFrom":"127.0.0.1:36308","lastDispatchedTo":"127.0.0.1:8094","requestId":8,"requestType":"SearchRequest","retried":0,"service":{"indexName":"search","type":"search"},"status":"INVALID_ARGS","timeoutMs":75000,"timings":{"dispatchMicros":2037,"totalMicros":15735}}
	at com.couchbase.client.core.io.netty.search.SearchChunkResponseParser.errorsToThrowable(SearchChunkResponseParser.java:97)
	at java.base/java.util.Optional.map(Optional.java:258)
	at com.couchbase.client.core.io.netty.search.SearchChunkResponseParser.error(SearchChunkResponseParser.java:79)
	at com.couchbase.client.core.io.netty.chunk.ChunkedMessageHandler.lambda$maybeCompleteResponseWithFailure$1(ChunkedMessageHandler.java:260)
	at java.base/java.util.Optional.orElseGet(Optional.java:362)
	at com.couchbase.client.core.io.netty.chunk.ChunkedMessageHandler.maybeCompleteResponseWithFailure(ChunkedMessageHandler.java:259)
	at com.couchbase.client.core.io.netty.chunk.ChunkedMessageHandler.channelRead(ChunkedMessageHandler.java:191)
	at com.couchbase.client.core.deps.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at com.couchbase.client.core.deps.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at com.couchbase.client.core.deps.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at com.couchbase.client.core.deps.io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
	at com.couchbase.client.core.deps.io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
	at com.couchbase.client.core.deps.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at com.couchbase.client.core.deps.io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
	at com.couchbase.client.core.deps.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at com.couchbase.client.core.deps.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at com.couchbase.client.core.deps.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at com.couchbase.client.core.deps.io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at com.couchbase.client.core.deps.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at com.couchbase.client.core.deps.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at com.couchbase.client.core.deps.io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at com.couchbase.client.core.deps.io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:792)
	at com.couchbase.client.core.deps.io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:475)
	at com.couchbase.client.core.deps.io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378)
	at com.couchbase.client.core.deps.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at com.couchbase.client.core.deps.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at com.couchbase.client.core.deps.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:832)
```