### PR TITLE
Do not required optional errors field in FTS response

### DIFF
--- a/scala-client/src/main/scala/com/couchbase/client/scala/query/handlers/SearchHandler.scala
+++ b/scala-client/src/main/scala/com/couchbase/client/scala/query/handlers/SearchHandler.scala
@@ -104,7 +104,7 @@ object SearchHandler {
       totalPartitionCount   <- status.numLong("total")
       successPartitionCount <- status.numLong("successful")
       errorPartitionCount   <- status.numLong("failed")
-      errors                <- status.obj("errors")
+      errors                = status.obj("errors").getOrElse(JsonObjectSafe.create)
 
       metrics <- Try(
         SearchMetrics(


### PR DESCRIPTION
The `errors` field seems to be not included in FTS query responses.
This causes the parsing of the metadata to fail and therefore e.g. total amount of results is not available.

I've tried to fix the error so far, but unfortunately I do not know the FTS protocol very well.
The documentation for the search doesn't seem to be nearly as detailed as the documentation for N1QL.
I would be pleased if someone who is more familiar with it would take a closer look at that whole function.

```
{
    "status": {
        "total": 6,
        "failed": 0,
        "successful": 6
    },
    "request": { ... },
    "hits": { ... },
    "total_hits": 621,
    "max_score": 0.15896573080584536,
    "took": 5390234,
    "facets": null
}
```