### PR TITLE
Cleanups to OpenTelemetry tracing.

### DIFF
--- a/tracing-opentelemetry/src/main/java/com/couchbase/client/tracing/opentelemetry/OpenTelemetryRequestSpan.java
+++ b/tracing-opentelemetry/src/main/java/com/couchbase/client/tracing/opentelemetry/OpenTelemetryRequestSpan.java
@@ -78,9 +78,7 @@ public class OpenTelemetryRequestSpan implements RequestSpan {
 
   @Override
   public void end() {
-    try (Scope scope = span.makeCurrent()) {
-      span.end();
-    }
+    span.end();
   }
 
   @Override

--- a/tracing-opentelemetry/src/main/java/com/couchbase/client/tracing/opentelemetry/OpenTelemetryRequestTracer.java
+++ b/tracing-opentelemetry/src/main/java/com/couchbase/client/tracing/opentelemetry/OpenTelemetryRequestTracer.java
@@ -50,7 +50,7 @@ public class OpenTelemetryRequestTracer implements RequestTracer {
   }
 
   private OpenTelemetryRequestTracer(OpenTelemetry openTelemetry) {
-    this.tracer = openTelemetry.getTracer("com.couchbase.client");
+    this.tracer = openTelemetry.getTracer("com.couchbase.client.java");
   }
 
   private Span castSpan(final RequestSpan requestSpan) {

--- a/tracing-opentelemetry/src/main/java/com/couchbase/client/tracing/opentelemetry/OpenTelemetryRequestTracer.java
+++ b/tracing-opentelemetry/src/main/java/com/couchbase/client/tracing/opentelemetry/OpenTelemetryRequestTracer.java
@@ -50,7 +50,7 @@ public class OpenTelemetryRequestTracer implements RequestTracer {
   }
 
   private OpenTelemetryRequestTracer(OpenTelemetry openTelemetry) {
-    this.tracer = openTelemetry.getTracer("com.couchbase.client.java");
+    this.tracer = openTelemetry.getTracer("com.couchbase.client.jvm");
   }
 
   private Span castSpan(final RequestSpan requestSpan) {


### PR DESCRIPTION
Hello, I'm an OpenTelemetry maintainer - thanks for using OpenTelemetry for tracing in this project :)

I've applied some cleanups to this project to match some of the guidelines we have in https://github.com/open-telemetry/opentelemetry-java-instrumentation

- Accept `OpenTelemetry` instance to instrumentation instead of `Tracer`. Tracer name should be determined by the library, not by the user
- Don't call `setNoParent` when couchbase didn't provide a parent span. Couchbase spans still need to parent to, e.g. a spring-boot server span
- Don't call `makeCurrent` - it is to make a span active in a threadlocal for a block of code, but immediately calling close is effectively an expensive no-op, and it's not needed for `Span.end()` either. Since you propagate parent `RequestSpan` within the SDK, you don't need to ever use `makeCurrent` I think.

One big remaining issue seems to be the span kind - couchbase spans corresponding to a user operation should be `CLIENT`, not `INTERNAL`. But I think that would involve a mapping from `operationName` to kind which I'm not familiar enough to solve myself.