### PR TITLE
fix build for scala 2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Couchbase JVM Clients
-
+ 
 [![license](https://img.shields.io/github/license/couchbase/couchbase-jvm-clients?color=brightgreen)](https://opensource.org/licenses/Apache-2.0)
 [![java-client](https://img.shields.io/maven-central/v/com.couchbase.client/java-client?color=brightgreen&label=java-client)](https://search.maven.org/artifact/com.couchbase.client/java-client)
 [![scala-client](https://img.shields.io/maven-central/v/com.couchbase.client/scala-client_2.12?color=brightgreen&label=scala-client)](https://search.maven.org/artifact/com.couchbase.client/scala-client_2.12)

--- a/scala-client/pom.xml
+++ b/scala-client/pom.xml
@@ -324,6 +324,7 @@
                         <!--Required for Scala 2.11 build, this enables support for Java SAM.  This is on by default in-->
                         <!--Scala 2.12+ -->
                         <arg>-Xexperimental</arg>
+                        <arg>-language:postfixOps</arg>
                         <arg>-target:jvm-1.8</arg>
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>

--- a/scala-client/src/main/scala/com/couchbase/client/scala/manager/bucket/BucketSettings.scala
+++ b/scala-client/src/main/scala/com/couchbase/client/scala/manager/bucket/BucketSettings.scala
@@ -326,7 +326,7 @@ object BucketSettings {
   def parseSeqFrom(raw: Array[Byte]): Seq[BucketSettings] = {
     val jsonArr = JsonArray.fromJson(new String(raw, StandardCharsets.UTF_8)).get
     import scala.collection.JavaConverters._
-    jsonArr.values.asScala.map(v => {
+    jsonArr.values.asScala.toSeq.map(v => {
       val j = v.asInstanceOf[JsonObject]
       parseFrom(j)
     })


### PR DESCRIPTION
These two minor changes builds the scala-client for Scala 2.13. These don't fix deprecation warnings.