### PR TITLE
Proposing convenience `OpenTelemetryRequestTracer#warpGlobal()`

### DIFF
--- a/metrics-opentelemetry/src/main/java/com/couchbase/client/metrics/opentelemetry/OpenTelemetryMeter.java
+++ b/metrics-opentelemetry/src/main/java/com/couchbase/client/metrics/opentelemetry/OpenTelemetryMeter.java
@@ -72,6 +72,11 @@ public class OpenTelemetryMeter implements Meter {
   private final Map<NameAndTags, OpenTelemetryValueRecorder> valueRecorders = new ConcurrentHashMap<>();
 
   @Stability.Volatile
+  public static OpenTelemetryMeter wrapGlobal() {
+    return wrap(GlobalOpenTelemetry.get());
+  }
+  
+  @Stability.Volatile
   public static OpenTelemetryMeter wrap(final OpenTelemetry openTelemetry) {
     return new OpenTelemetryMeter(openTelemetry.getMeterProvider());
   }

--- a/metrics-opentelemetry/src/main/java/com/couchbase/client/metrics/opentelemetry/OpenTelemetryMeter.java
+++ b/metrics-opentelemetry/src/main/java/com/couchbase/client/metrics/opentelemetry/OpenTelemetryMeter.java
@@ -23,6 +23,7 @@ import com.couchbase.client.core.cnc.ValueRecorder;
 import com.couchbase.client.core.cnc.metrics.NameAndTags;
 import com.couchbase.client.core.env.CoreEnvironment;
 import com.couchbase.client.core.error.MeterException;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogram;

--- a/tracing-opentelemetry/src/main/java/com/couchbase/client/tracing/opentelemetry/OpenTelemetryRequestTracer.java
+++ b/tracing-opentelemetry/src/main/java/com/couchbase/client/tracing/opentelemetry/OpenTelemetryRequestTracer.java
@@ -76,6 +76,16 @@ public class OpenTelemetryRequestTracer implements RequestTracer {
   private final Tracer tracer;
 
   /**
+   * Wraps the global OpenTelemetry obtained through {@link GlobalOpenTelemetry#get()} and returns a datatype that can 
+   * be passed into the requestTracer method of the environment.
+   *
+   * @return the wrapped global OpenTelemetry ready to be passed in.
+   */
+  public static OpenTelemetryRequestTracer wrapGlobal() {
+    return wrap(GlobalOpenTelemetry.get());
+  }
+  
+  /**
    * Wraps OpenTelemetry and returns a datatype that can be passed into the requestTracer method of the
    * environment.
    *

--- a/tracing-opentelemetry/src/main/java/com/couchbase/client/tracing/opentelemetry/OpenTelemetryRequestTracer.java
+++ b/tracing-opentelemetry/src/main/java/com/couchbase/client/tracing/opentelemetry/OpenTelemetryRequestTracer.java
@@ -20,6 +20,7 @@ import com.couchbase.client.core.cnc.RequestSpan;
 import com.couchbase.client.core.cnc.RequestTracer;
 import com.couchbase.client.core.env.CoreEnvironment;
 import com.couchbase.client.core.error.TracerException;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;


### PR DESCRIPTION
Whenever an `OpenTelemetry` is properly registered, it can be automatically obtained through `GlobalOpenTelemetry.get()`, which may reduce some of the setup burden from the user and make it truly vendor neutral.