### PR TITLE
Replaced some assertions with AssertJ

### DIFF
--- a/core-io/src/test/java/com/couchbase/client/core/cnc/AbstractContextTest.java
+++ b/core-io/src/test/java/com/couchbase/client/core/cnc/AbstractContextTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static com.couchbase.client.core.util.CbCollections.mapOf;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -47,7 +48,7 @@ class AbstractContextTest {
         input.put("foo", "bar");
       }
     };
-    assertEquals("{\n  \"foo\" : \"bar\"\n}", ctx.exportAsString(Context.ExportFormat.JSON_PRETTY));
+    assertThat("{\n  \"foo\" : \"bar\"\n}").isEqualToIgnoringNewLines(ctx.exportAsString(Context.ExportFormat.JSON_PRETTY));
   }
 
   @Test

--- a/core-io/src/test/java/com/couchbase/client/core/cnc/DefaultLoggerFormatterTest.java
+++ b/core-io/src/test/java/com/couchbase/client/core/cnc/DefaultLoggerFormatterTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.util.logging.Level;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class DefaultLoggerFormatterTest {
@@ -30,7 +31,7 @@ class DefaultLoggerFormatterTest {
 
     DefaultLoggerFormatter formatter = DefaultLoggerFormatter.INSTANCE;
     String result = formatter.format(Level.INFO, "my message", null);
-    assertEquals("[ INFO] (" + currentThread + ") my message\n", result);
+    assertThat("[ INFO] (" + currentThread + ") my message\n").isEqualToIgnoringNewLines(result);
   }
 
   @Test


### PR DESCRIPTION
Tests on "core-io" are failing on Windows due to platform-dependent line separator (\n). The lines have actually the same content, but not for the testing engine. I thought about multiple different solutions (use System.lineSeparator(), set separator before each test or maybe use a VM parameter), but this one seems to be the most optimal.
These two files aren't the only ones causing the problem, there are others. I can continue on working, if this solutions is ok for the project.