### PR TITLE
Added support for Micrometer Observation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repository contains the following projects:
  - `java-client`: the Java language binding
  - `scala-client`: the Scala language binding
  - `kotlin-client`: the Kotlin language binding
+ - `tracing-observation`: module to integrate with [Micrometer Observation](https://micrometer.io/docs/observation)
  - `tracing-opentracing`: module to integrate with [OpenTracing](https://opentracing.io/)
  - `tracing-opentelemetry`: module to integrate with [OpenTelemetry](https://opentelemetry.io/) tracing
  - `metrics-opentelemetry`: module to integrate with [OpenTelemetry](https://opentelemetry.io/) metrics

--- a/core-io/src/main/java/com/couchbase/client/core/cnc/CbTracing.java
+++ b/core-io/src/main/java/com/couchbase/client/core/cnc/CbTracing.java
@@ -72,7 +72,7 @@ public class CbTracing {
    */
   public static RequestSpan newSpan(RequestTracer tracer, String spanName, RequestSpan parent) {
     RequestSpan span = tracer.requestSpan(spanName, parent);
-    span.attribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
+    span.lowCardinalityAttribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
     return span;
   }
 

--- a/core-io/src/main/java/com/couchbase/client/core/cnc/RequestSpan.java
+++ b/core-io/src/main/java/com/couchbase/client/core/cnc/RequestSpan.java
@@ -32,7 +32,7 @@ import java.time.Instant;
 public interface RequestSpan {
 
   /**
-   * Sets an attribute on the span, which is translated to the corresponding implementation specific tag.
+   * Sets a high-cardinality attribute on the span, which is translated to the corresponding implementation specific tag.
    * <p>
    * Note that, depending on the implementation, attributes might be ignored.
    *
@@ -42,7 +42,7 @@ public interface RequestSpan {
   void attribute(String key, String value);
 
   /**
-   * Sets an attribute on the span, which is translated to the corresponding implementation specific tag.
+   * Sets a high-cardinality attribute on the span, which is translated to the corresponding implementation specific tag.
    * <p>
    * Note that, depending on the implementation, attributes might be ignored.
    *
@@ -52,7 +52,7 @@ public interface RequestSpan {
   void attribute(String key, boolean value);
 
   /**
-   * Sets an attribute on the span, which is translated to the corresponding implementation specific tag.
+   * Sets a high-cardinality attribute on the span, which is translated to the corresponding implementation specific tag.
    * <p>
    * Note that, depending on the implementation, attributes might be ignored.
    *
@@ -60,6 +60,42 @@ public interface RequestSpan {
    * @param value the value of the attribute.
    */
   void attribute(String key, long value);
+
+  /**
+   * Sets a low-cardinality attribute on the span, which is translated to the corresponding implementation specific tag.
+   * <p>
+   * Note that, depending on the implementation, attributes might be ignored.
+   *
+   * @param key the key of the attribute.
+   * @param value the value of the attribute.
+   */
+  default void lowCardinalityAttribute(String key, String value) {
+    attribute(key, value);
+  }
+
+  /**
+   * Sets a low-cardinality attribute on the span, which is translated to the corresponding implementation specific tag.
+   * <p>
+   * Note that, depending on the implementation, attributes might be ignored.
+   *
+   * @param key the key of the attribute.
+   * @param value the value of the attribute.
+   */
+  default void lowCardinalityAttribute(String key, boolean value) {
+    attribute(key, value);
+  }
+
+  /**
+   * Sets a low-cardinality attribute on the span, which is translated to the corresponding implementation specific tag.
+   * <p>
+   * Note that, depending on the implementation, attributes might be ignored.
+   *
+   * @param key the key of the attribute.
+   * @param value the value of the attribute.
+   */
+  default void lowCardinalityAttribute(String key, long value) {
+    attribute(key, value);
+  }
 
   /**
    * Sets an event on the span, which is translated to the corresponding implementation specific event.

--- a/core-io/src/main/java/com/couchbase/client/core/endpoint/http/CoreHttpRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/endpoint/http/CoreHttpRequest.java
@@ -92,7 +92,7 @@ public class CoreHttpRequest extends BaseRequest<CoreHttpResponse>
     this.bypassExceptionTranslation = builder.bypassExceptionTranslation;
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_SERVICE, CbTracing.getTracingId(target.serviceType()));
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_SERVICE, CbTracing.getTracingId(target.serviceType()));
       span.attribute(TracingIdentifiers.ATTR_OPERATION, builder.method + " " + builder.path.format());
     }
   }
@@ -306,7 +306,7 @@ public class CoreHttpRequest extends BaseRequest<CoreHttpResponse>
 
       if (span != null && !CbTracing.isInternalSpan(span)) {
         if (target.bucketName() != null) {
-          span.attribute(TracingIdentifiers.ATTR_NAME, target.bucketName());
+          span.lowCardinalityAttribute(TracingIdentifiers.ATTR_NAME, target.bucketName());
         }
         CbTracing.setAttributes(span, spanAttributes);
       }

--- a/core-io/src/main/java/com/couchbase/client/core/io/netty/TracingUtils.java
+++ b/core-io/src/main/java/com/couchbase/client/core/io/netty/TracingUtils.java
@@ -49,8 +49,8 @@ public class TracingUtils {
                                                      @Nullable final String localHost, final int localPort,
                                                      @Nullable final String remoteHost, final int remotePort,
                                                      @Nullable final String operationId) {
-    span.attribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
-    span.attribute(TracingIdentifiers.ATTR_NET_TRANSPORT, TracingIdentifiers.ATTR_NET_TRANSPORT_TCP);
+    span.lowCardinalityAttribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
+    span.lowCardinalityAttribute(TracingIdentifiers.ATTR_NET_TRANSPORT, TracingIdentifiers.ATTR_NET_TRANSPORT_TCP);
 
     if (localId != null) {
       span.attribute(TracingIdentifiers.ATTR_LOCAL_ID, localId);
@@ -87,7 +87,7 @@ public class TracingUtils {
     if (request instanceof SyncDurabilityRequest) {
       SyncDurabilityRequest syncDurabilityRequest = (SyncDurabilityRequest) request;
       if (syncDurabilityRequest.durabilityLevel() != null) {
-        span.attribute(TracingIdentifiers.ATTR_DURABILITY,
+        span.lowCardinalityAttribute(TracingIdentifiers.ATTR_DURABILITY,
                 syncDurabilityRequest.durabilityLevel().map(Enum::name).orElse(DurabilityLevel.NONE.name()));
       }
     }

--- a/core-io/src/main/java/com/couchbase/client/core/manager/CoreCollectionQueryIndexManager.java
+++ b/core-io/src/main/java/com/couchbase/client/core/manager/CoreCollectionQueryIndexManager.java
@@ -258,7 +258,7 @@ public class CoreCollectionQueryIndexManager {
     Set<String> indexNameSet = new HashSet<>(indexNames);
 
     RequestSpan parent = requestTracer.requestSpan(TracingIdentifiers.SPAN_REQUEST_MQ_WATCH_INDEXES, null);
-    parent.attribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
+    parent.lowCardinalityAttribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
 
     return Mono.fromFuture(() -> failIfIndexesOffline(indexNameSet, options.watchPrimary(), parent))
             .retryWhen(Retry.onlyIf(ctx -> hasCause(ctx.exception(), IndexesNotReadyException.class))
@@ -367,7 +367,7 @@ public class CoreCollectionQueryIndexManager {
   private CompletableFuture<CoreQueryResult> exec(CoreQueryType queryType, CharSequence statement,
                                                   CoreCommonOptions options, String spanName, ObjectNode parameters) {
     RequestSpan parent = requestTracer.requestSpan(spanName, options.parentSpan().orElse(null));
-    parent.attribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
+    parent.lowCardinalityAttribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
 
     CoreCommonOptions common = CoreCommonOptions.ofOptional(options.timeout(), options.retryStrategy(), Optional.of(parent));
 

--- a/core-io/src/main/java/com/couchbase/client/core/manager/CoreQueryIndexManager.java
+++ b/core-io/src/main/java/com/couchbase/client/core/manager/CoreQueryIndexManager.java
@@ -306,7 +306,7 @@ public class CoreQueryIndexManager {
     Set<String> indexNameSet = new HashSet<>(indexNames);
 
     RequestSpan parent = requestTracer.requestSpan(TracingIdentifiers.SPAN_REQUEST_MQ_WATCH_INDEXES, null);
-    parent.attribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
+    parent.lowCardinalityAttribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
 
     return Mono.fromFuture(() -> failIfIndexesOffline(bucketName, indexNameSet, options.watchPrimary(), parent, options.scopeAndCollection()))
             .retryWhen(Retry.onlyIf(ctx -> hasCause(ctx.exception(), IndexesNotReadyException.class))
@@ -359,7 +359,7 @@ public class CoreQueryIndexManager {
                                                   CoreCommonOptions options, String spanName, String bucketName,
                                                   ObjectNode parameters) {
     RequestSpan parent = requestTracer.requestSpan(spanName, options.parentSpan().orElse(null));
-    parent.attribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
+    parent.lowCardinalityAttribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
 
     CoreCommonOptions common = CoreCommonOptions.ofOptional(options.timeout(), options.retryStrategy(), Optional.of(parent));
 

--- a/core-io/src/main/java/com/couchbase/client/core/msg/BaseRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/BaseRequest.java
@@ -142,7 +142,7 @@ public abstract class BaseRequest<R extends Response> implements Request<R> {
       requestSpan.requestContext(this.ctx);
 
       if (!CbTracing.isInternalSpan(requestSpan)) {
-        requestSpan.attribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
+        requestSpan.lowCardinalityAttribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
       }
     }
 

--- a/core-io/src/main/java/com/couchbase/client/core/msg/analytics/AnalyticsRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/analytics/AnalyticsRequest.java
@@ -90,7 +90,7 @@ public class AnalyticsRequest
     this.scope = scope;
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_SERVICE, TracingIdentifiers.SERVICE_ANALYTICS);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_SERVICE, TracingIdentifiers.SERVICE_ANALYTICS);
       span.attribute(TracingIdentifiers.ATTR_STATEMENT, statement);
       if (bucket != null) {
         span.attribute(TracingIdentifiers.ATTR_NAME, bucket);

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/AppendRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/AppendRequest.java
@@ -54,7 +54,7 @@ public class AppendRequest extends BaseKeyValueRequest<AppendResponse> implement
     this.syncReplicationType = syncReplicationType;
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_APPEND);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_APPEND);
       applyLevelOnSpan(syncReplicationType, span);
     }
   }

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/BaseKeyValueRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/BaseKeyValueRequest.java
@@ -110,7 +110,7 @@ public abstract class BaseKeyValueRequest<R extends Response>
     this.opaque = nextOpaque();
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_SERVICE, TracingIdentifiers.SERVICE_KV);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_SERVICE, TracingIdentifiers.SERVICE_KV);
       setCommonKVSpanAttributes(span, (KeyValueRequest<Response>) this);
     }
   }

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/DecrementRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/DecrementRequest.java
@@ -62,7 +62,7 @@ public class DecrementRequest extends BaseKeyValueRequest<DecrementResponse> imp
     this.syncReplicationType = syncReplicationType;
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_DECREMENT);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_DECREMENT);
       applyLevelOnSpan(syncReplicationType, span);
     }
   }

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/GetAndLockRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/GetAndLockRequest.java
@@ -49,7 +49,7 @@ public class GetAndLockRequest extends BaseKeyValueRequest<GetAndLockResponse> {
     this.lockFor = lockFor;
 
     if (span != null) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_GET_AND_LOCK);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_GET_AND_LOCK);
     }
   }
 

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/GetAndTouchRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/GetAndTouchRequest.java
@@ -49,7 +49,7 @@ public class GetAndTouchRequest extends BaseKeyValueRequest<GetAndTouchResponse>
     this.expiration = expiration;
 
     if (span != null) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_GET_AND_TOUCH);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_GET_AND_TOUCH);
     }
   }
 

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/GetMetaRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/GetMetaRequest.java
@@ -48,7 +48,7 @@ public class GetMetaRequest extends BaseKeyValueRequest<GetMetaResponse> {
     super(timeout, ctx, retryStrategy, key, collectionIdentifier, span);
 
     if (span != null) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_EXISTS);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_EXISTS);
     }
   }
 

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/GetRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/GetRequest.java
@@ -55,7 +55,7 @@ public class GetRequest extends BaseKeyValueRequest<GetResponse> {
     super(timeout, ctx, retryStrategy, key, collectionIdentifier, span);
 
     if (span != null) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_GET);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_GET);
     }
   }
 

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/IncrementRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/IncrementRequest.java
@@ -64,7 +64,7 @@ public class IncrementRequest extends BaseKeyValueRequest<IncrementResponse> imp
     this.syncReplicationType = syncReplicationType;
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_INCREMENT);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_INCREMENT);
       applyLevelOnSpan(syncReplicationType, span);
     }
   }

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/InsertRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/InsertRequest.java
@@ -65,7 +65,7 @@ public class InsertRequest extends BaseKeyValueRequest<InsertResponse> implement
     this.syncReplicationType = syncReplicationType;
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_INSERT);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_INSERT);
       applyLevelOnSpan(syncReplicationType, span);
     }
   }

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/ObserveViaSeqnoRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/ObserveViaSeqnoRequest.java
@@ -48,7 +48,7 @@ public class ObserveViaSeqnoRequest extends BaseKeyValueRequest<ObserveViaSeqnoR
     this.vbucketUUID = vbucketUUID;
 
     if (span != null) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_OBSERVE);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_OBSERVE);
     }
   }
 

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/PrependRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/PrependRequest.java
@@ -54,7 +54,7 @@ public class PrependRequest extends BaseKeyValueRequest<PrependResponse> impleme
     this.syncReplicationType = syncReplicationType;
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_PREPEND);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_PREPEND);
       applyLevelOnSpan(syncReplicationType, span);
     }
   }

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/RemoveRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/RemoveRequest.java
@@ -53,7 +53,7 @@ public class RemoveRequest extends BaseKeyValueRequest<RemoveResponse> implement
     this.syncReplicationType = syncReplicationType;
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_REMOVE);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_REMOVE);
       applyLevelOnSpan(syncReplicationType, span);
     }
   }

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/ReplaceRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/ReplaceRequest.java
@@ -73,7 +73,7 @@ public class ReplaceRequest extends BaseKeyValueRequest<ReplaceResponse> impleme
     this.syncReplicationType = syncReplicationType;
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_REPLACE);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_REPLACE);
       applyLevelOnSpan(syncReplicationType, span);
     }
   }

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/ReplicaGetRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/ReplicaGetRequest.java
@@ -46,7 +46,7 @@ public class ReplicaGetRequest extends GetRequest {
     this.replica = replica;
 
     if (span != null) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_GET_REPLICA);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_GET_REPLICA);
     }
   }
 

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/SubdocGetRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/SubdocGetRequest.java
@@ -85,7 +85,7 @@ public class SubdocGetRequest extends BaseKeyValueRequest<SubdocGetResponse> {
     this.origKey = key;
 
     if (span != null) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_LOOKUP_IN);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_LOOKUP_IN);
     }
   }
 

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/SubdocMutateRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/SubdocMutateRequest.java
@@ -211,7 +211,7 @@ public class SubdocMutateRequest extends BaseKeyValueRequest<SubdocMutateRespons
     this.createAsDeleted = createAsDeleted;
 
     if (span != null) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_MUTATE_IN);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_MUTATE_IN);
       applyLevelOnSpan(syncReplicationType, span);
     }
   }

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/SyncDurabilityRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/SyncDurabilityRequest.java
@@ -41,13 +41,13 @@ public interface SyncDurabilityRequest {
     if (level.isPresent() && span != null) {
       switch (level.get()) {
         case MAJORITY:
-          span.attribute(TracingIdentifiers.ATTR_DURABILITY, "majority");
+          span.lowCardinalityAttribute(TracingIdentifiers.ATTR_DURABILITY, "majority");
           break;
         case MAJORITY_AND_PERSIST_TO_ACTIVE:
-          span.attribute(TracingIdentifiers.ATTR_DURABILITY, "majority_and_persist_active");
+          span.lowCardinalityAttribute(TracingIdentifiers.ATTR_DURABILITY, "majority_and_persist_active");
           break;
         case PERSIST_TO_MAJORITY:
-          span.attribute(TracingIdentifiers.ATTR_DURABILITY, "persist_majority");
+          span.lowCardinalityAttribute(TracingIdentifiers.ATTR_DURABILITY, "persist_majority");
           break;
       }
     }

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/TouchRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/TouchRequest.java
@@ -46,7 +46,7 @@ public class TouchRequest extends BaseKeyValueRequest<TouchResponse> {
     this.expiry = expiry;
 
     if (span != null) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_TOUCH);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_TOUCH);
     }
   }
 

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/UnlockRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/UnlockRequest.java
@@ -46,7 +46,7 @@ public class UnlockRequest extends BaseKeyValueRequest<UnlockResponse> {
     this.cas = cas;
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_UNLOCK);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_UNLOCK);
     }
   }
 

--- a/core-io/src/main/java/com/couchbase/client/core/msg/kv/UpsertRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/kv/UpsertRequest.java
@@ -66,7 +66,7 @@ public class UpsertRequest extends BaseKeyValueRequest<UpsertResponse> implement
     this.syncReplicationType = syncReplicationType;
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_UPSERT);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TracingIdentifiers.SPAN_REQUEST_KV_UPSERT);
       applyLevelOnSpan(syncReplicationType, span);
     }
   }

--- a/core-io/src/main/java/com/couchbase/client/core/msg/manager/GenericManagerRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/manager/GenericManagerRequest.java
@@ -56,7 +56,7 @@ public class GenericManagerRequest extends BaseManagerRequest<GenericManagerResp
     this.idempotent = idempotent;
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_SERVICE, TracingIdentifiers.SERVICE_MGMT);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_SERVICE, TracingIdentifiers.SERVICE_MGMT);
 
       FullHttpRequest request = requestSupplier.get();
       span.attribute(TracingIdentifiers.ATTR_OPERATION, request.method().toString() + " " + request.uri());

--- a/core-io/src/main/java/com/couchbase/client/core/msg/query/QueryRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/query/QueryRequest.java
@@ -82,7 +82,7 @@ public class QueryRequest
     this.target = target;
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_SERVICE, TracingIdentifiers.SERVICE_QUERY);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_SERVICE, TracingIdentifiers.SERVICE_QUERY);
       span.attribute(TracingIdentifiers.ATTR_STATEMENT, statement);
       if (bucket != null) {
         span.attribute(TracingIdentifiers.ATTR_NAME, bucket);

--- a/core-io/src/main/java/com/couchbase/client/core/msg/search/SearchRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/search/SearchRequest.java
@@ -58,7 +58,7 @@ public class SearchRequest extends BaseRequest<SearchResponse>
         this.scope = scope;
 
         if (span != null && !CbTracing.isInternalSpan(span)) {
-            span.attribute(TracingIdentifiers.ATTR_SERVICE, TracingIdentifiers.SERVICE_SEARCH);
+            span.lowCardinalityAttribute(TracingIdentifiers.ATTR_SERVICE, TracingIdentifiers.SERVICE_SEARCH);
             span.attribute(TracingIdentifiers.ATTR_OPERATION, indexName);
         }
     }

--- a/core-io/src/main/java/com/couchbase/client/core/msg/view/ViewRequest.java
+++ b/core-io/src/main/java/com/couchbase/client/core/msg/view/ViewRequest.java
@@ -72,7 +72,7 @@ public class ViewRequest extends BaseRequest<ViewResponse>
     this.keysJson = requireNonNull(keysJson);
 
     if (span != null && !CbTracing.isInternalSpan(span)) {
-      span.attribute(TracingIdentifiers.ATTR_SERVICE, TracingIdentifiers.SERVICE_VIEWS);
+      span.lowCardinalityAttribute(TracingIdentifiers.ATTR_SERVICE, TracingIdentifiers.SERVICE_VIEWS);
       span.attribute(TracingIdentifiers.ATTR_OPERATION, "/" + design + "/" + view);
       span.attribute(TracingIdentifiers.ATTR_NAME, bucket);
     }

--- a/core-io/src/main/java/com/couchbase/client/core/protostellar/CoreProtostellarUtil.java
+++ b/core-io/src/main/java/com/couchbase/client/core/protostellar/CoreProtostellarUtil.java
@@ -179,13 +179,13 @@ public class CoreProtostellarUtil {
     if (!durability.isNone() && !durability.isLegacy()) {
       switch (durability.levelIfSynchronous().get()) {
         case MAJORITY:
-          span.attribute(TracingIdentifiers.ATTR_DURABILITY, "majority");
+          span.lowCardinalityAttribute(TracingIdentifiers.ATTR_DURABILITY, "majority");
           break;
         case MAJORITY_AND_PERSIST_TO_ACTIVE:
-          span.attribute(TracingIdentifiers.ATTR_DURABILITY, "majority_and_persist_active");
+          span.lowCardinalityAttribute(TracingIdentifiers.ATTR_DURABILITY, "majority_and_persist_active");
           break;
         case PERSIST_TO_MAJORITY:
-          span.attribute(TracingIdentifiers.ATTR_DURABILITY, "persist_majority");
+          span.lowCardinalityAttribute(TracingIdentifiers.ATTR_DURABILITY, "persist_majority");
           break;
       }
     }

--- a/core-io/src/main/java/com/couchbase/client/core/service/kv/ReplicaHelper.java
+++ b/core-io/src/main/java/com/couchbase/client/core/service/kv/ReplicaHelper.java
@@ -102,7 +102,7 @@ public class ReplicaHelper {
 
     CoreEnvironment env = core.context().environment();
     RequestSpan getAllSpan = env.requestTracer().requestSpan(TracingIdentifiers.SPAN_GET_ALL_REPLICAS, parentSpan);
-    getAllSpan.attribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
+    getAllSpan.lowCardinalityAttribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
 
     return Reactor
         .toMono(() -> getAllReplicasRequests(core, collectionIdentifier, documentId, clientContext, retryStrategy, timeout, getAllSpan))
@@ -140,7 +140,7 @@ public class ReplicaHelper {
   ) {
     CoreEnvironment env = core.context().environment();
     RequestSpan getAllSpan = env.requestTracer().requestSpan(TracingIdentifiers.SPAN_GET_ALL_REPLICAS, parentSpan);
-    getAllSpan.attribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
+    getAllSpan.lowCardinalityAttribute(TracingIdentifiers.ATTR_SYSTEM, TracingIdentifiers.ATTR_SYSTEM_COUCHBASE);
 
     return getAllReplicasRequests(core, collectionIdentifier, documentId, clientContext, retryStrategy, timeout, getAllSpan)
         .thenApply(stream ->

--- a/core-io/src/main/java/com/couchbase/client/core/transaction/cleanup/TransactionsCleaner.java
+++ b/core-io/src/main/java/com/couchbase/client/core/transaction/cleanup/TransactionsCleaner.java
@@ -395,7 +395,7 @@ public class TransactionsCleaner {
                 .attribute(TracingIdentifiers.ATTR_TRANSACTION_STATE, req.state());
 
         req.durabilityLevel().ifPresent(v -> {
-            span.attribute(TracingIdentifiers.ATTR_DURABILITY, DurabilityLevelUtil.convertDurabilityLevel(v));
+            span.lowCardinalityAttribute(TracingIdentifiers.ATTR_DURABILITY, DurabilityLevelUtil.convertDurabilityLevel(v));
         });
 
         return Mono.defer(() -> {

--- a/core-io/src/main/java/com/couchbase/client/core/transaction/support/SpanWrapper.java
+++ b/core-io/src/main/java/com/couchbase/client/core/transaction/support/SpanWrapper.java
@@ -74,6 +74,13 @@ public class SpanWrapper {
         return this;
     }
 
+    public <T> SpanWrapper lowCardinalityAttribute(String key, T value) {
+        if (!isInternal) {
+            span.lowCardinalityAttribute(key, String.valueOf(value));
+        }
+        return this;
+    }
+
     public RequestSpan span() {
         return span;
     }

--- a/java-client/src/main/java/com/couchbase/client/java/transactions/ReactiveTransactionAttemptContext.java
+++ b/java-client/src/main/java/com/couchbase/client/java/transactions/ReactiveTransactionAttemptContext.java
@@ -83,7 +83,7 @@ public class ReactiveTransactionAttemptContext {
      */
     public Mono<TransactionGetResult> insert(ReactiveCollection collection, String id, Object content) {
         RequestSpan span = CbTracing.newSpan(internal.core().context(), TRANSACTION_OP_INSERT, internal.span());
-        span.attribute(TracingIdentifiers.ATTR_OPERATION, TRANSACTION_OP_INSERT);
+        span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TRANSACTION_OP_INSERT);
         byte[] encoded = encode(content, span, serializer, internal.core().context());
 
         return internal.insert(makeCollectionIdentifier(collection.async()), id, encoded, new SpanWrapper(span))
@@ -106,7 +106,7 @@ public class ReactiveTransactionAttemptContext {
      */
     public Mono<TransactionGetResult> replace(TransactionGetResult doc, Object content) {
         RequestSpan span = CbTracing.newSpan(internal.core().context(), TRANSACTION_OP_REPLACE, internal.span());
-        span.attribute(TracingIdentifiers.ATTR_OPERATION, TRANSACTION_OP_REPLACE);
+        span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TRANSACTION_OP_REPLACE);
         byte[] encoded = encode(content, span, serializer, internal.core().context());
         return internal.replace(doc.internal(), encoded, new SpanWrapper(span))
                 .map(result -> new TransactionGetResult(result, serializer()))
@@ -121,7 +121,7 @@ public class ReactiveTransactionAttemptContext {
      */
     public Mono<Void> remove(TransactionGetResult doc) {
         RequestSpan span = CbTracing.newSpan(internal.core().context(), TRANSACTION_OP_REMOVE, internal.span());
-        span.attribute(TracingIdentifiers.ATTR_OPERATION, TRANSACTION_OP_REMOVE);
+        span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TRANSACTION_OP_REMOVE);
         return internal.remove(doc.internal(), new SpanWrapper(span))
                 .doOnError(err -> span.status(RequestSpan.StatusCode.ERROR))
                 .doOnTerminate(() -> span.end());

--- a/java-client/src/main/java/com/couchbase/client/java/transactions/TransactionAttemptContext.java
+++ b/java-client/src/main/java/com/couchbase/client/java/transactions/TransactionAttemptContext.java
@@ -110,7 +110,7 @@ public class TransactionAttemptContext {
      */
     public TransactionGetResult replace(TransactionGetResult doc, Object content) {
         RequestSpan span = CbTracing.newSpan(internal.core().context(), TRANSACTION_OP_REPLACE, internal.span());
-        span.attribute(TracingIdentifiers.ATTR_OPERATION, TRANSACTION_OP_REPLACE);
+        span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TRANSACTION_OP_REPLACE);
         byte[] encoded = encode(content, span, serializer, internal.core().context());
         return internal.replace(doc.internal(), encoded, new SpanWrapper(span))
                 .map(result -> new TransactionGetResult(result, serializer()))
@@ -141,7 +141,7 @@ public class TransactionAttemptContext {
      */
     public TransactionGetResult insert(Collection collection, String id, Object content) {
         RequestSpan span = CbTracing.newSpan(internal.core().context(), TRANSACTION_OP_INSERT, internal.span());
-        span.attribute(TracingIdentifiers.ATTR_OPERATION, TRANSACTION_OP_INSERT);
+        span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TRANSACTION_OP_INSERT);
         byte[] encoded = encode(content, span, serializer, internal.core().context());
         return internal.insert(makeCollectionIdentifier(collection.async()), id, encoded, new SpanWrapper(span))
                 .map(result -> new TransactionGetResult(result, serializer()))
@@ -166,7 +166,7 @@ public class TransactionAttemptContext {
      */
     public void remove(TransactionGetResult doc) {
         RequestSpan span = CbTracing.newSpan(internal.core().context(), TRANSACTION_OP_REMOVE, internal.span());
-        span.attribute(TracingIdentifiers.ATTR_OPERATION, TRANSACTION_OP_REMOVE);
+        span.lowCardinalityAttribute(TracingIdentifiers.ATTR_OPERATION, TRANSACTION_OP_REMOVE);
         internal.remove(doc.internal(), new SpanWrapper(span))
                 .doOnError(err -> span.status(RequestSpan.StatusCode.ERROR))
                 .doOnTerminate(() -> span.end())

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
         <module>scala-client</module>
         <module>kotlin-client</module>
         <module>test-utils</module>
+        <module>tracing-observation</module>
         <module>tracing-opentracing</module>
         <module>tracing-opentelemetry</module>
         <module>metrics-opentelemetry</module>

--- a/test-utils/src/main/java/com/couchbase/client/test/Util.java
+++ b/test-utils/src/main/java/com/couchbase/client/test/Util.java
@@ -24,6 +24,9 @@ import java.time.Duration;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
+import org.awaitility.core.ThrowingRunnable;
+import org.junit.jupiter.api.function.ThrowingSupplier;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.awaitility.Awaitility.with;
 
@@ -42,6 +45,14 @@ public class Util {
    */
   public static void waitUntilCondition(final BooleanSupplier supplier) {
     waitUntilCondition(supplier, Duration.ofMinutes(1));
+  }
+
+  public static void waitUntilCondition(final ThrowingRunnable runnable) {
+    waitUntilCondition(runnable, Duration.ofMinutes(1));
+  }
+
+  public static void waitUntilCondition(final ThrowingRunnable runnable, Duration atMost) {
+    with().pollInterval(Duration.ofMillis(1)).await().atMost(atMost).untilAsserted(runnable);
   }
 
   public static void waitUntilCondition(final BooleanSupplier supplier, Duration atMost) {

--- a/tracing-observation/pom.xml
+++ b/tracing-observation/pom.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.couchbase.client</groupId>
+        <artifactId>couchbase-jvm-clients</artifactId>
+        <version>1.13.6-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>tracing-observation</artifactId>
+    <version>1.2.6-SNAPSHOT</version>
+
+    <name>Micrometer Observation Interoperability</name>
+    <description>Provides interoperability with Micrometer Observation</description>
+
+    <properties>
+        <micrometer.version>1.10.6</micrometer.version>
+        <micrometer-tracing.version>1.0.4</micrometer-tracing.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.couchbase.client</groupId>
+            <artifactId>core-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.couchbase.client</groupId>
+            <artifactId>java-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.couchbase.client</groupId>
+            <artifactId>test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-integration-test</artifactId>
+            <version>${micrometer-tracing.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j-slf4j-impl.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <source>8</source>
+                            <doclint>none</doclint>
+                            <quiet>true</quiet>
+                            <stylesheetfile>${project.basedir}/../config/javadoc/style.css</stylesheetfile>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <links>
+                        <link>https://projectreactor.io/docs/core/release/api/</link>
+                    </links>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${build-helper-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>add-integration-test-source-as-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <!-- add the following sources in addition to the unit tests -->
+                                <source>${java-test-source-directory}</source>
+                                <source>${scala-test-source-directory}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-integration-test-resource-as-test-resource</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${test-resource-directory}</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals><goal>create</goal></goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                    <shortRevisionLength>8</shortRevisionLength>
+                    <attach>true</attach>
+                    <addOutputDirectoryToResources>true</addOutputDirectoryToResources>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Build-Time>${maven.build.timestamp}</Build-Time>
+                            <Automatic-Module-Name>com.couchbase.client.tracing.observation</Automatic-Module-Name>
+                        </manifestEntries>
+                        <manifestSections>
+                            <manifestSection>
+                                <!-- the part after couchbase- needs to match with the agent title in the env -->
+                                <name>couchbase-java-tracing-observation</name>
+                                <manifestEntries>
+                                    <Impl-Version>${project.version}</Impl-Version>
+                                    <Impl-Git-Revision>${buildNumber}</Impl-Git-Revision>
+                                </manifestEntries>
+                            </manifestSection>
+                        </manifestSections>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <!-- by default, add also the int tests -->
+                <java-test-source-directory>src/integrationTest/java</java-test-source-directory>
+                <scala-test-source-directory>src/integrationTest/scala</scala-test-source-directory>
+                <test-resource-directory>src/integrationTest/resources</test-resource-directory>
+            </properties>
+        </profile>
+        <profile>
+            <id>unit</id>
+            <activation>
+                <property>
+                    <name>unit</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- just adding the unit tests again, noop. -->
+                <test-source-directory>src/test/java</test-source-directory>
+                <test-resource-directory>src/test/resources</test-resource-directory>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/tracing-observation/src/integrationTest/java/com/couchbase/client/tracing/observation/ObservationTracingIntegrationTest.java
+++ b/tracing-observation/src/integrationTest/java/com/couchbase/client/tracing/observation/ObservationTracingIntegrationTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2019 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.client.tracing.observation;
+
+import com.couchbase.client.core.cnc.TracingIdentifiers;
+import com.couchbase.client.core.error.DocumentNotFoundException;
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.Collection;
+import com.couchbase.client.test.ClusterAwareIntegrationTest;
+import com.couchbase.client.test.Services;
+import com.couchbase.client.test.TestNodeConfig;
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import io.micrometer.core.tck.MeterRegistryAssert;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.exporter.FinishedSpan;
+import io.micrometer.tracing.test.SampleTestRunner;
+import io.micrometer.tracing.test.simple.SpansAssert;
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+
+import static com.couchbase.client.java.ClusterOptions.clusterOptions;
+import static com.couchbase.client.test.Util.waitUntilCondition;
+
+class ObservationTracingIntegrationTest extends ClusterAwareIntegrationTest {
+
+  private static final Logger log = LoggerFactory.getLogger(ObservationTracingIntegrationTest.class);
+
+  private static Cluster cluster;
+  private static Collection collection;
+
+  static void beforeEach(ObservationRegistry observationRegistry) {
+    TestNodeConfig config = config().firstNodeWith(Services.KV).get();
+
+    cluster = Cluster.connect(
+      String.format("couchbase://%s:%d", config.hostname(), config.ports().get(Services.KV)),
+      clusterOptions(config().adminUsername(), config().adminPassword())
+        .environment(env -> env.requestTracer(ObservationRequestTracer.wrap(observationRegistry)))
+    );
+    Bucket bucket = cluster.bucket(config().bucketname());
+    collection = bucket.defaultCollection();
+
+    bucket.waitUntilReady(Duration.ofSeconds(30));
+  }
+
+  @AfterEach
+  void afterAll() {
+    if (cluster != null) {
+      cluster.disconnect();
+      cluster = null;
+    }
+  }
+
+
+  @Nested
+  class IntegrationTest extends SampleTestRunner {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public SampleTestRunnerConsumer yourCode() throws Exception {
+      return (bb, meterRegistry) -> {
+        ObservationTracingIntegrationTest.beforeEach(getObservationRegistry());
+
+        Span parent = bb.getTracer().currentSpan();
+        log.info("Running the query");
+        try {
+          collection.get("myid");
+        } catch (DocumentNotFoundException ignored) {
+          // expected
+        }
+
+        log.info("Asserting results");
+        waitUntilCondition(() -> {
+          log.debug("Found following spans " + bb.getFinishedSpans());
+          SpansAssert.assertThat(bb.getFinishedSpans())
+              .hasASpanWithName("get", spanAssert -> {
+                spanAssert
+                  .hasKindEqualTo(Span.Kind.CLIENT)
+                  .hasTag("db.system", "couchbase")
+                  .hasTag("db.operation", "get")
+                  .hasTag("db.couchbase.service", "kv")
+                  .hasTag("db.couchbase.collection", "_default")
+                  .hasTag("db.couchbase.scope", "_default")
+                  .has(new Condition<FinishedSpan>() {
+                    @Override
+                    public boolean matches(FinishedSpan value) {
+                      return value.getParentId().equals(parent.context().spanId());
+                    }
+                  });
+              });
+          log.info("Span <get> found");
+          SpansAssert.assertThat(bb.getFinishedSpans())
+            .hasASpanWithName("dispatch_to_server", spanAssert -> {
+              spanAssert
+                .hasKindEqualTo(Span.Kind.CLIENT)
+                .hasTag("db.system", "couchbase");
+            });
+          log.info("Span <dispatch_to_server> found");
+          MeterRegistryAssert.assertThat(meterRegistry)
+            .hasMeterWithNameAndTags(TracingIdentifiers.METER_OPERATIONS, KeyValues.of(KeyValue.of("db.system", "couchbase")));
+          log.info("Timer found");
+        });
+      };
+    }
+  }
+
+  @Nested
+  class StressTest extends SampleTestRunner {
+
+    @Override
+    public SampleTestRunnerConsumer yourCode() throws Exception {
+      return (bb, meterRegistry) -> {
+
+        ObservationTracingIntegrationTest.beforeEach(getObservationRegistry());
+
+        int numRequests = 100;
+        for (int i = 0; i < 100; i++) {
+          try {
+            collection.get("foo-" + i);
+          } catch (DocumentNotFoundException x) {
+            // expected
+          }
+        }
+
+        waitUntilCondition(() -> {
+          SpansAssert.then(bb.getFinishedSpans()).hasSizeGreaterThanOrEqualTo(numRequests);
+          return true;
+        });
+      };
+    }
+  }
+
+}

--- a/tracing-observation/src/integrationTest/resources/integration.properties
+++ b/tracing-observation/src/integrationTest/resources/integration.properties
@@ -1,0 +1,24 @@
+# Couchbase Integration-Test Default Properties
+
+# If set to false, it is assumed that the host is managing the cluster and
+# as a result no containers or anything will be spun up.
+# Options: containerized, mocked, unmanaged
+cluster.type=mocked
+
+# Default configs for both cases
+cluster.adminUsername=Administrator
+cluster.adminPassword=password
+
+# Default configs for the mocked environment
+cluster.mocked.numNodes=1
+cluster.mocked.numReplicas=1
+
+# Default configs if managed
+cluster.containerized.version=VULCAN
+cluster.containerized.numNodes=1
+cluster.containerized.numReplicas=1
+
+# Entry point configuration if not managed
+# value of hostname and ns_server port
+cluster.unmanaged.seed=127.0.0.1:8091
+cluster.unmanaged.numReplicas=0

--- a/tracing-observation/src/integrationTest/resources/log4j2-test.xml
+++ b/tracing-observation/src/integrationTest/resources/log4j2-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss} %-5p [%c:%L] %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="warn">
+            <AppenderRef ref="Console" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/tracing-observation/src/main/java/com/couchbase/client/tracing/observation/CouchbaseSenderContext.java
+++ b/tracing-observation/src/main/java/com/couchbase/client/tracing/observation/CouchbaseSenderContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.client.tracing.observation;
+
+import io.micrometer.observation.transport.Kind;
+import io.micrometer.observation.transport.SenderContext;
+
+import static com.couchbase.client.core.util.Validators.notNull;
+
+/**
+ * A {@link SenderContext} for Couchbase.
+ *
+ * @author Marcin Grzejszczak
+ */
+public class CouchbaseSenderContext extends SenderContext<Object> {
+
+  private final String operationName;
+
+  public CouchbaseSenderContext(String operationName) {
+    super((o, s, s1) -> { }, Kind.CLIENT);
+    this.operationName = operationName;
+  }
+
+  public String getOperationName() {
+    return operationName;
+  }
+}

--- a/tracing-observation/src/main/java/com/couchbase/client/tracing/observation/ObservationRequestSpan.java
+++ b/tracing-observation/src/main/java/com/couchbase/client/tracing/observation/ObservationRequestSpan.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.client.tracing.observation;
+
+import java.time.Instant;
+
+import com.couchbase.client.core.cnc.RequestSpan;
+import com.couchbase.client.core.msg.RequestContext;
+import io.micrometer.observation.Observation;
+
+import static com.couchbase.client.core.util.Validators.notNull;
+
+/**
+ * Wraps a Micrometer Observation, ready to be passed in into options for each operation into the SDK as a parent.
+ *
+ * @author Marcin Grzejszczak
+ */
+public class ObservationRequestSpan implements RequestSpan {
+
+  /**
+   * The Micrometer Observation.
+   */
+  private final Observation observation;
+
+  private ObservationRequestSpan(final Observation observation) {
+    this.observation = notNull(observation, "Observation");
+  }
+
+  /**
+   * Wraps a Micrometer Observation so that it can be passed in to the SDK-operation options as a parent.
+   *
+   * @param observation the observation that should act as the parent.
+   * @return the created wrapped observation.
+   */
+  public static ObservationRequestSpan wrap(final Observation observation) {
+    return new ObservationRequestSpan(observation);
+  }
+
+  /**
+   * Returns the wrapped Micrometer Observation.
+   */
+  public Observation observation() {
+    return observation;
+  }
+
+  @Override
+  public void attribute(String key, String value) {
+    if (value != null) {
+      observation.highCardinalityKeyValue(key, value);
+    }
+  }
+
+  @Override
+  public void attribute(String key, boolean value) {
+    observation.highCardinalityKeyValue(key, String.valueOf(value));
+  }
+
+  @Override
+  public void attribute(String key, long value) {
+    observation.highCardinalityKeyValue(key, String.valueOf(value));
+  }
+
+  @Override
+  public void lowCardinalityAttribute(String key, String value) {
+    observation.lowCardinalityKeyValue(key, value);
+  }
+
+  @Override
+  public void lowCardinalityAttribute(String key, boolean value) {
+    lowCardinalityAttribute(key, String.valueOf(value));
+  }
+
+  @Override
+  public void lowCardinalityAttribute(String key, long value) {
+    lowCardinalityAttribute(key, String.valueOf(value));
+  }
+
+  @Override
+  public void event(String name, Instant timestamp) {
+    // This can lead to creation of strange metrics (name would equal metric name)
+    // and we've seen users put arbitrary text (e.g. stacktraces) as span events
+    // so for safety measures we are not doing any events
+  }
+
+  @Override
+  public void status(StatusCode status) {
+    // Not supported by Micrometer Observation
+  }
+
+  @Override
+  public void recordException(Throwable err) {
+    observation.error(err);
+  }
+
+  @Override
+  public void end() {
+    observation.stop();
+  }
+
+  @Override
+  public void requestContext(final RequestContext requestContext) {
+    // no need for the request context in this implementation
+  }
+}

--- a/tracing-observation/src/main/java/com/couchbase/client/tracing/observation/ObservationRequestTracer.java
+++ b/tracing-observation/src/main/java/com/couchbase/client/tracing/observation/ObservationRequestTracer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.client.tracing.observation;
+
+import com.couchbase.client.core.cnc.RequestSpan;
+import com.couchbase.client.core.cnc.RequestTracer;
+import com.couchbase.client.core.cnc.TracingIdentifiers;
+import com.couchbase.client.core.error.TracerException;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+/**
+ * Wraps the Micrometer Observation, so it is suitable to be passed in into the couchbase environment and picked up
+ * by the rest of the SDK as a result.
+ *
+ * @author Marcin Grzejszczak
+ */
+public class ObservationRequestTracer implements RequestTracer {
+
+  /**
+   * Holds the ObservationRegistry.
+   */
+  private final ObservationRegistry observationRegistry;
+
+  /**
+   * Wraps ObservationRegistry and returns a datatype that can be passed into the requestTracer method of the
+   * environment.
+   *
+   * @param observationRegistry the ObservationRegistry instance to wrap.
+   * @return the wrapped ObservationRegistry ready to be passed in.
+   */
+  public static ObservationRequestTracer wrap(ObservationRegistry observationRegistry) {
+    return new ObservationRequestTracer(observationRegistry);
+  }
+
+  private ObservationRequestTracer(ObservationRegistry observationRegistry) {
+    this.observationRegistry = observationRegistry;
+  }
+
+  private Observation castObservation(final RequestSpan requestSpan) {
+    if (requestSpan == null) {
+      return null;
+    }
+
+    if (requestSpan instanceof ObservationRequestSpan) {
+      return ((ObservationRequestSpan) requestSpan).observation();
+    } else {
+      throw new IllegalArgumentException("RequestSpan must be of type ObservationRequestSpan");
+    }
+  }
+
+  /**
+   * Returns the inner ObservationRegistry
+   */
+  public ObservationRegistry observationRegistry() {
+    return observationRegistry;
+  }
+
+  @Override
+  public RequestSpan requestSpan(String operationName, RequestSpan parent) {
+    try {
+      CouchbaseSenderContext senderContext = new CouchbaseSenderContext(operationName);
+      if (parent != null) {
+        senderContext.setParentObservation(castObservation(parent));
+      }
+      Observation observation = Observation.createNotStarted(TracingIdentifiers.METER_OPERATIONS, () -> senderContext, observationRegistry)
+        .contextualName(operationName);
+      return ObservationRequestSpan.wrap(observation.start());
+    } catch (Exception ex) {
+      throw new TracerException("Failed to create ObservationRequestSpan", ex);
+    }
+  }
+
+  @Override
+  public Mono<Void> start() {
+    return Mono.empty(); // Tracer is not started by us
+  }
+
+  @Override
+  public Mono<Void> stop(Duration timeout) {
+    return Mono.empty(); // Tracer should not be stopped by us
+  }
+
+}


### PR DESCRIPTION
fixes https://issues.couchbase.com/browse/JCBC-2046

This results in automatic creation of spans and metrics (and whatever else you configure through `ObservationRegistry`). Below you can find an example of the setup for Metrics with Micrometer Core and Tracing with Micrometer Tracing.

```
15:03:31 INFO  [io.micrometer.tracing.test.SampleTestRunner:183] Gathered the following metrics
	Meter with name <db.couchbase.operations.active> and type <LONG_TASK_TIMER> has the following measurements 
		<[Measurement{statistic='ACTIVE_TASKS', value=0.0}, Measurement{statistic='DURATION', value=0.0}]> 
		and has the following tags <[]>
	Meter with name <db.couchbase.operations> and type <TIMER> has the following measurements 
		<[Measurement{statistic='COUNT', value=1.0}, Measurement{statistic='TOTAL_TIME', value=0.002471388}, Measurement{statistic='MAX', value=0.002471388}]> 
		and has the following tags <[tag(db.system=couchbase), tag(error=none), tag(net.transport=IP.TCP)]>
	Meter with name <zipkin_brave.active> and type <LONG_TASK_TIMER> has the following measurements 
		<[Measurement{statistic='ACTIVE_TASKS', value=1.0}, Measurement{statistic='DURATION', value=0.178993099}]> 
		and has the following tags <[]>
	Meter with name <db.couchbase.operations> and type <TIMER> has the following measurements 
		<[Measurement{statistic='COUNT', value=1.0}, Measurement{statistic='TOTAL_TIME', value=0.003121377}, Measurement{statistic='MAX', value=0.003121377}]> 
		and has the following tags <[tag(db.couchbase.service=kv), tag(db.operation=get), tag(db.system=couchbase), tag(error=CompletionException)]>
```

![image](https://user-images.githubusercontent.com/3297437/233379142-ab005632-a31c-4278-9a6c-6dbfa8276f60.png)
