### PR TITLE
centralize log4j-slf4j-impl scope and fix blockhound scope

### DIFF
--- a/core-io/pom.xml
+++ b/core-io/pom.xml
@@ -55,6 +55,9 @@
         <dependency>
             <groupId>io.projectreactor.tools</groupId>
             <artifactId>blockhound</artifactId>
+            <!-- Override the `provided` scope from dependencyManagement: core-io calls BlockHound.install()
+                 from production code and therefore needs compile classpath access. -->
+            <scope>compile</scope>
             <optional>true</optional>
         </dependency>
 
@@ -78,8 +81,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j-slf4j-impl.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.couchbase.client</groupId>

--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -44,8 +44,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j-slf4j-impl.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/kotlin-client/pom.xml
+++ b/kotlin-client/pom.xml
@@ -134,8 +134,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j-slf4j-impl.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,15 @@
                 <groupId>io.projectreactor.tools</groupId>
                 <artifactId>blockhound</artifactId>
                 <version>${blockhound.version}</version>
+                <!-- BlockHound is a Java agent loaded via -javaagent; it must never leak as a transitive compile dependency. -->
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j-slf4j-impl.version}</version>
+                <!-- Test-only SLF4J binding; centralized here as the single source of truth. -->
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>

--- a/tracing-opentelemetry/pom.xml
+++ b/tracing-opentelemetry/pom.xml
@@ -68,8 +68,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j-slf4j-impl.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
centralize log4j-slf4j-impl scope and fix blockhound scope in dependencyManagement

- Add log4j-slf4j-impl to root dependencyManagement with test scope, remove redundant version/scope declarations from core-io, java-client, kotlin-client, and tracing-opentelemetry
- Set blockhound to 'provided' scope in dependencyManagement to prevent it leaking as a transitive compile dependency (it is a Java agent)
- Override blockhound scope to 'compile' in core-io, which calls BlockHound.install() from production code