### PR TITLE
Update Netty and Jackson versions in 3.11.x

### DIFF
--- a/core-io-deps/pom.xml
+++ b/core-io-deps/pom.xml
@@ -18,8 +18,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- When bumping this, it may be necessary to bump the grpc-netty dependency in protostellar/pom.xml also -->
-        <netty.version>4.2.12.Final</netty.version>
-        <jackson.version>2.21.2</jackson.version>
+        <netty.version>4.2.15.Final</netty.version>
+        <jackson.version>2.21.4</jackson.version>
 
         <shaded.package.prefix>com.couchbase.client.core.deps.</shaded.package.prefix>
         <shaded.native.lib.prefix>com_couchbase_client_core_deps_</shaded.native.lib.prefix>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <assertj.version>3.23.1</assertj.version>
         <log4j-slf4j-impl.version>2.25.3</log4j-slf4j-impl.version>
 
-        <jackson.version>2.21.2</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
         <reactor.version>3.6.9</reactor.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <blockhound.version>1.0.16.RELEASE</blockhound.version>


### PR DESCRIPTION
Update Netty and Jackson versions in a hope to create a 3.11.4 release that will be comptaible with Spring Data Couchbase