### PR TITLE
TEST: Fix error annotation in GHA workflows

### DIFF
--- a/core-io/src/test/java/com/couchbase/client/core/transaction/util/BlockingWaitGroupTest.java
+++ b/core-io/src/test/java/com/couchbase/client/core/transaction/util/BlockingWaitGroupTest.java
@@ -21,11 +21,19 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.concurrent.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BlockingWaitGroupTest {
 
@@ -238,7 +246,12 @@ class BlockingWaitGroupTest {
     wg.add("operation");
 
     Thread awaitThread = new Thread(() -> {
-      wg.await(Duration.ofSeconds(10));
+      try {
+        wg.await(Duration.ofSeconds(10));
+      } catch (RuntimeException e) {
+        if (!(e.getCause() instanceof InterruptedException)) throw e; // unexpected
+        // exit gracefully instead of throwing, so GHA doesn't create a failure annotation.
+      }
     });
     awaitThread.start();
 


### PR DESCRIPTION
BlockingWaitGroupTest.awaitInterruptedWhenThreadInterrupted() was letting the thread terminate due to an expected exception. This cased the thread's uncaught exception handler to log a message that GHA interprets as cause for alarm.

This change swallows the expected exception, so GHA no longer adds an error annotation to the job summary.