### PR TITLE
TEST: Upgrade to OkHttp 5.5.0

### DIFF
--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -35,8 +35,8 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>3.14.9</version>
+            <artifactId>okhttp-jvm</artifactId>
+            <version>5.5.0</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor.tools</groupId>


### PR DESCRIPTION
So we don't get a vulnerability warning from GitHub on every push.