### PR TITLE
Propagate failed RetryStrategy futures immediately

### DIFF
--- a/core-io/src/main/java/com/couchbase/client/core/retry/RetryOrchestrator.java
+++ b/core-io/src/main/java/com/couchbase/client/core/retry/RetryOrchestrator.java
@@ -71,6 +71,8 @@ public class RetryOrchestrator {
         ctx.environment().eventBus().publish(
           new RequestNotRetriedEvent(Event.Severity.INFO, request.getClass(), request.context(), reason, throwable)
         );
+        request.cancel(CancellationReason.noMoreRetries(reason), ignored -> throwable);
+        return;
       }
 
       Optional<Duration> duration = retryAction.duration();

--- a/java-client/src/integrationTest/java/com/couchbase/client/java/RetryStrategyIntegrationTest.java
+++ b/java-client/src/integrationTest/java/com/couchbase/client/java/RetryStrategyIntegrationTest.java
@@ -82,6 +82,35 @@ class RetryStrategyIntegrationTest extends JavaIntegrationTest {
     collection.remove(docId);
   }
 
+  @Test
+  void retryStrategyFailurePropagates() {
+    String docId = UUID.randomUUID().toString();
+    RetryStrategy failIfLocked = new BestEffortRetryStrategy() {
+      @Override
+      public CompletableFuture<RetryAction> shouldRetry(final Request<? extends Response> request, final RetryReason reason) {
+        if (reason == RetryReason.KV_LOCKED) {
+          CompletableFuture<RetryAction> result = new CompletableFuture<>();
+          result.completeExceptionally(new IllegalStateException("retry strategy failed"));
+          return result;
+        }
+        return super.shouldRetry(request, reason);
+      }
+    };
+
+    collection.upsert(docId, "foo");
+    GetResult r = collection.getAndLock(docId, Duration.ofSeconds(15));
+
+    try {
+      assertThrows(IllegalStateException.class, () ->
+          collection.remove(docId, removeOptions()
+              .retryStrategy(failIfLocked)
+              .timeout(Duration.ofSeconds(1))));
+    } finally {
+      collection.unlock(docId, r.cas());
+      collection.remove(docId);
+    }
+  }
+
   @AfterAll
   static void tearDown() {
     cluster.disconnect();


### PR DESCRIPTION
When a custom `RetryStrategy` fails while deciding whether to retry a locked-document operation, the request stays pending until its timeout. The caller receives an `AmbiguousTimeoutException` instead of the retry strategy failure.

The failed future currently leaves a null `RetryAction` in the completion callback. This change cancels the request with the original failure and stops the callback. Successful retry and no-retry actions keep their existing behavior.

Closes https://github.com/couchbase/couchbase-jvm-clients/issues/69

## Testing

The regression locks a real document in Couchbase Server Community 7.6.2, then removes it with a retry strategy that fails on `KV_LOCKED`.

<details>
<summary>Raw logs</summary>

Before:

```console
$ ./mvnw -pl java-client -am -Dtest=RetryStrategyIntegrationTest \
    -Dsurefire.failIfNoSpecifiedTests=false \
    -Dcluster.type=unmanaged -Dcluster.unmanaged.bucket=default test
Suppressed: java.lang.NullPointerException: Cannot invoke
"com.couchbase.client.core.retry.RetryAction.duration()"
because "retryAction" is null
Unexpected exception type thrown, expected: <java.lang.IllegalStateException>
but was: <com.couchbase.client.core.error.AmbiguousTimeoutException>
Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
BUILD FAILURE
```

After:

```console
$ ./mvnw -pl java-client -am -Dtest=RetryStrategyIntegrationTest \
    -Dsurefire.failIfNoSpecifiedTests=false \
    -Dcluster.type=unmanaged -Dcluster.unmanaged.bucket=default test
Request RemoveRequest not retried per RetryStrategy (Reason: KV_LOCKED)
java.lang.IllegalStateException: retry strategy failed
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

$ ./mvnw -pl core-io -am -Dtest=RetryOrchestratorTest \
    -Dsurefire.failIfNoSpecifiedTests=false test
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

</details>
