### PR TITLE
cherry-pick 3.12.x JVMCBC-1762 Failed RetryStrategy futures become operation timeouts

### DIFF
--- a/core-io/src/main/java/com/couchbase/client/core/retry/RetryOrchestrator.java
+++ b/core-io/src/main/java/com/couchbase/client/core/retry/RetryOrchestrator.java
@@ -71,6 +71,8 @@ public class RetryOrchestrator {
         ctx.environment().eventBus().publish(
           new RequestNotRetriedEvent(Event.Severity.INFO, request.getClass(), request.context(), reason, throwable)
         );
+        request.cancel(CancellationReason.noMoreRetries(reason), ignored -> throwable);
+        return;
       }
 
       Optional<Duration> duration = retryAction.duration();

--- a/java-client/src/integrationTest/java/com/couchbase/client/java/RetryStrategyIntegrationTest.java
+++ b/java-client/src/integrationTest/java/com/couchbase/client/java/RetryStrategyIntegrationTest.java
@@ -82,6 +82,35 @@ class RetryStrategyIntegrationTest extends JavaIntegrationTest {
     collection.remove(docId);
   }
 
+  @Test
+  void retryStrategyFailurePropagates() {
+    String docId = UUID.randomUUID().toString();
+    RetryStrategy failIfLocked = new BestEffortRetryStrategy() {
+      @Override
+      public CompletableFuture<RetryAction> shouldRetry(final Request<? extends Response> request, final RetryReason reason) {
+        if (reason == RetryReason.KV_LOCKED) {
+          CompletableFuture<RetryAction> result = new CompletableFuture<>();
+          result.completeExceptionally(new IllegalStateException("retry strategy failed"));
+          return result;
+        }
+        return super.shouldRetry(request, reason);
+      }
+    };
+
+    collection.upsert(docId, "foo");
+    GetResult r = collection.getAndLock(docId, Duration.ofSeconds(15));
+
+    try {
+      assertThrows(IllegalStateException.class, () ->
+          collection.remove(docId, removeOptions()
+              .retryStrategy(failIfLocked)
+              .timeout(Duration.ofSeconds(1))));
+    } finally {
+      collection.unlock(docId, r.cas());
+      collection.remove(docId);
+    }
+  }
+
   @AfterAll
   static void tearDown() {
     cluster.disconnect();


### PR DESCRIPTION
Returning a failed future from RetryStrategy.shouldRetry() now immediately causes the request to fail and propagates the exception from the failed future. Before this change, the request would simply time out.